### PR TITLE
Add features

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,9 +1,6 @@
 {
-	"ImportPath": "github.com/btobolaski/terraform-provider-linode",
-	"GoVersion": "go1.4.2",
-	"Packages": [
-		"github.com/btobolaski/terraform-provider-linode/..."
-	],
+	"ImportPath": "github.com/bdwyertech/terraform-provider-linode",
+	"GoVersion": "go1.5.1",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -12,7 +9,7 @@
 		},
 		{
 			"ImportPath": "github.com/btobolaski/linodego",
-			"Rev": "e42b03e28c7a3905c1bbfeb2041fcdb64f909fa0"
+			"Rev": "c77e7148c8ef754f82b130e472a873e2e7e02620"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/errwrap",

--- a/bin/terraform-provider-linode/main.go
+++ b/bin/terraform-provider-linode/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/btobolaski/terraform-provider-linode"
+	"github.com/bdwyertech/terraform-provider-linode"
 	"github.com/hashicorp/terraform/plugin"
 )
 

--- a/how_to_build.md
+++ b/how_to_build.md
@@ -1,0 +1,5 @@
+To build:
+
+1. godep install
+2. cd /bin/terraform-provider-linode
+3. go build

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,10 @@ resource "linode_linode" "foobar" {
 	region = "Dallas, TX, USA"
 	size = 1024
 	status = "on"
+	swap_size = 256
 	ip_address = "8.8.8.8"
+	plan_storage = 24576
+	plan_storage_utilized = 24576
 	private_networking = true
 	private_ip_address = "192.168.10.50"
 	ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCxtdizvJzTT38y2oXuoLUXbLUf9V0Jy9KsM0bgIvjUCSEbuLWCXKnWqgBmkv7iTKGZg3fx6JA10hiufdGHD7at5YaRUitGP2mvC2I68AYNZmLCGXh0hYMrrUB01OEXHaYhpSmXIBc9zUdTreL5CvYe3PAYzuBA0/lGFTnNsHosSd+suA4xfJWMr/Fr4/uxrpcy8N8BE16pm4kci5tcMh6rGUGtDEj6aE9k8OI4SRmSZJsNElsu/Z/K4zqCpkW/U06vOnRrE98j3NE07nxVOTqdAMZqopFiMP0MXWvd6XyS2/uKU+COLLc0+hVsgj+dVMTWfy8wZ58OJDsIKk/cI/7yF+GZz89Js+qYx7u9mNhpEgD4UrcRHpitlRgVhA8p6R4oBqb0m/rpKBd2BAFdcty3GIP9CWsARtsCbN6YDLJ1JN3xI34jSGC1ROktVHg27bEEiT5A75w3WJl96BlSo5zJsIZDTWlaqnr26YxNHba4ILdVLKigQtQpf8WFsnB9YzmDdb9K3w9szf5lAkb/SFXw+e+yPS9habkpOncL0oCsgag5wUGCEmZ7wpiY8QgARhuwsQUkxv1aUi/Nn7b7sAkKSkxtBI3LBXZ+vcUxZTH0ut4pe9rbrEed3ktAOF5FafjA1VtarPqqZ+g46xVO9llgpXcl3rVglFtXzTcUy09hGw== btobolaski@Brendans-MacBook-Pro.local"
@@ -73,12 +76,12 @@ resource "linode_linode" "foobar" {
 
 value                             | Type     | Forces New | Value Type | Description
 --------------------------------- | -------- | ---------- | ---------- | -----------
-`image`                           | Required | yes        | string     | The image to use when creating the linode. [^1]
+`image`                           | Required | yes        | string     | The image to use when creating the linode.  This can also be an ImageID [^1]
 `kernel`                          | Required | no         | string     | The kernel to start the linode with. If you can specify `"Latest 64-bit"` or `"Latest 32-bit"` for the most recent version of either that linode provices
 `name`                            | Optional | no         | string     | The name of the linode
 `group`                           | Optional | no         | string     | The group of the linode
 `region`                          | Required | yes        | string     | The region that the linode will be created in
-`size`                            | Required | yes        | int        | The amount of ram in the linode plan. i.e. 1024, 2048 or 4096
+`size`                            | Required | no         | int        | The amount of ram in the linode plan. i.e. 1024, 2048 or 4096
 `ip_address`                      | Computed | n/a        | string     | The public ip address
 `private_networking`              | Optional | sort of    | bool       | Whether or not to enable private networking. It can be enabled on an existing linode but it can't be disabled.
 `private_ip_address`              | Computed | n/a        | string     | If private networking is enabled, it will be populated with the linode's private ip address
@@ -86,6 +89,11 @@ value                             | Type     | Forces New | Value Type | Descrip
 `root_password`                   | Required | yes        | string     | Unfortunately this is required by the linode api. You'll likely want to modify this on the server during provisioning (which won't force a new linode) and then disable password logins for ssh.
 `helper_distro`                   | Optional | no         | bool       | Enable the Distro filesystem helper. Corrects fstab and inittab/upstart entries depending on the kernel you're booting. You want this unless you're providing your own kernel.
 `manage_private_ip_automatically` | Optional | no         | bool       | Automatically creates network configuration files for your distro and places them into your filesystem. Will reboot your linode when enabled.
+`disk_expansion`                  | Optional | no         | bool       | Setting this to true to true will automatically expand the root volume if the size of the linode plan is increased.  Setting this value will prevent downsizing without manually shrinking the volume prior to decreasing the size.
+`plan_storage`                    | Computed | n/a        | int        | The size of the Linode plans storage capacity in MB
+`plan_storage_utilized`           | Computed | n/a        | int        | The sum of the size of all the Linode's disks
+`swap_size`                       | Optional | no         | int        | Sets the size of the swap partition on a Linode in MB.  At this time, this cannot be modified by Terraform after initial provisioning.  If manually modified via the Web GUI, this value will reflect such modification.  This value can be set to 0 to create a Linode without a swap partition.  Defaults to 256.
+
 
 [^1]: While these technically could be modified, it requires destroying the root volume and creating a new volume which is practically the same as creating a new instance.
 
@@ -95,7 +103,7 @@ value                             | Type     | Forces New | Value Type | Descrip
 2. Use [godep][3] to get the correct versions of the dependencies
 3. Make your changes
 4. Apply `go fmt` to all of the files
-5. Verify that the tests still pass
+5. Verify that the tests still pass (`cd ${PROJECT_ROOT}` and `go test -v --timeout 20m`)
 6. Submit a pull request
 
 [3]:https://github.com/tools/godep

--- a/resource_linode.go
+++ b/resource_linode.go
@@ -121,7 +121,7 @@ func resourceLinodeLinode() *schema.Resource {
 			"swap_size": &schema.Schema{
 				Type: schema.TypeInt,
 				Optional: true,
-				Default: 256,
+				Default: 512,
 			},
 		},
 	}

--- a/resource_linode.go
+++ b/resource_linode.go
@@ -519,7 +519,7 @@ func getSizeId(client *linodego.Client, size int) (int, error) {
 			return s[i].PlanId, nil
 		}
 	}
-	return -1, fmt.Errorf("Unable to locate the plan for size %d", size)
+	return -1, fmt.Errorf("Unable to locate the plan with RAM %d", size)
 }
 
 // getSize gets the amount of ram from the plan id
@@ -592,6 +592,8 @@ const (
 // findImage finds the specified image. It checks the prebuilt images first and then any custom images. It returns both
 // the image type and the images id
 func findImage(client *linodego.Client, imageName string) (imageType, imageId int, err error) {
+
+	// Get Available Distributions
 	distResp, err := client.Avail.Distributions()
 	if err != nil {
 		return -1, -1, err
@@ -603,6 +605,7 @@ func findImage(client *linodego.Client, imageName string) (imageType, imageId in
 		}
 	}
 
+	// Get Available Client Images
 	custResp, err := client.Image.List()
 	if err != nil {
 		return -1, -1, err
@@ -610,6 +613,9 @@ func findImage(client *linodego.Client, imageName string) (imageType, imageId in
 	customImages := custResp.Images
 	for i := range customImages {
 		if customImages[i].Label.String() == imageName {
+			return CUSTOM_IMAGE, customImages[i].ImageId, nil
+		}
+		if strconv.Itoa(customImages[i].ImageId) == imageName {
 			return CUSTOM_IMAGE, customImages[i].ImageId, nil
 		}
 	}

--- a/resource_linode_test.go
+++ b/resource_linode_test.go
@@ -69,18 +69,28 @@ func TestAccLinodeLinode_Resize(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLinodeLinodeDestroy,
 		Steps: []resource.TestStep{
+			// Start off with a Linode 1024
 			resource.TestStep{
-				Config: testAccCheckLinodeLinodeConfig_updates,
+				Config: testAccCheckLinodeLinodeConfig_Upsize_small,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLinodeLinodeExists("linode_linode.foobar"),
 					resource.TestCheckResourceAttr("linode_linode.foobar", "size", "1024"),
 				),
 			},
+			// Bump it to a 2048, but don't expand the disk
 			resource.TestStep{
-				Config: testAccCheckLinodeLinodeConfig_Resize,
+				Config: testAccCheckLinodeLinodeConfig_Upsize_bigger,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLinodeLinodeExists("linode_linode.foobar"),
 					resource.TestCheckResourceAttr("linode_linode.foobar", "size", "2048"),
+				),
+			},
+			// Go back down to a 1024
+			resource.TestStep{
+				Config: testAccCheckLinodeLinodeConfig_Downsize,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeLinodeExists("linode_linode.foobar"),
+					resource.TestCheckResourceAttr("linode_linode.foobar", "size", "1024"),
 				),
 			},
 		},
@@ -209,9 +219,45 @@ resource "linode_linode" "foobar" {
 	ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCxtdizvJzTT38y2oXuoLUXbLUf9V0Jy9KsM0bgIvjUCSEbuLWCXKnWqgBmkv7iTKGZg3fx6JA10hiufdGHD7at5YaRUitGP2mvC2I68AYNZmLCGXh0hYMrrUB01OEXHaYhpSmXIBc9zUdTreL5CvYe3PAYzuBA0/lGFTnNsHosSd+suA4xfJWMr/Fr4/uxrpcy8N8BE16pm4kci5tcMh6rGUGtDEj6aE9k8OI4SRmSZJsNElsu/Z/K4zqCpkW/U06vOnRrE98j3NE07nxVOTqdAMZqopFiMP0MXWvd6XyS2/uKU+COLLc0+hVsgj+dVMTWfy8wZ58OJDsIKk/cI/7yF+GZz89Js+qYx7u9mNhpEgD4UrcRHpitlRgVhA8p6R4oBqb0m/rpKBd2BAFdcty3GIP9CWsARtsCbN6YDLJ1JN3xI34jSGC1ROktVHg27bEEiT5A75w3WJl96BlSo5zJsIZDTWlaqnr26YxNHba4ILdVLKigQtQpf8WFsnB9YzmDdb9K3w9szf5lAkb/SFXw+e+yPS9habkpOncL0oCsgag5wUGCEmZ7wpiY8QgARhuwsQUkxv1aUi/Nn7b7sAkKSkxtBI3LBXZ+vcUxZTH0ut4pe9rbrEed3ktAOF5FafjA1VtarPqqZ+g46xVO9llgpXcl3rVglFtXzTcUy09hGw== btobolaski@Brendans-MacBook-Pro.local"
 }`
 
-const testAccCheckLinodeLinodeConfig_Resize = `
+const testAccCheckLinodeLinodeConfig_Upsize_small = `
 resource "linode_linode" "foobar" {
-	name = "foobaz"
+	name = "foobar_small"
+	group = "integration"
+	size = 1024
+	image = "Ubuntu 14.04 LTS"
+	region = "Dallas, TX, USA"
+	kernel = "Latest 64 bit"
+	root_password = "terraform-test"
+	ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCxtdizvJzTT38y2oXuoLUXbLUf9V0Jy9KsM0bgIvjUCSEbuLWCXKnWqgBmkv7iTKGZg3fx6JA10hiufdGHD7at5YaRUitGP2mvC2I68AYNZmLCGXh0hYMrrUB01OEXHaYhpSmXIBc9zUdTreL5CvYe3PAYzuBA0/lGFTnNsHosSd+suA4xfJWMr/Fr4/uxrpcy8N8BE16pm4kci5tcMh6rGUGtDEj6aE9k8OI4SRmSZJsNElsu/Z/K4zqCpkW/U06vOnRrE98j3NE07nxVOTqdAMZqopFiMP0MXWvd6XyS2/uKU+COLLc0+hVsgj+dVMTWfy8wZ58OJDsIKk/cI/7yF+GZz89Js+qYx7u9mNhpEgD4UrcRHpitlRgVhA8p6R4oBqb0m/rpKBd2BAFdcty3GIP9CWsARtsCbN6YDLJ1JN3xI34jSGC1ROktVHg27bEEiT5A75w3WJl96BlSo5zJsIZDTWlaqnr26YxNHba4ILdVLKigQtQpf8WFsnB9YzmDdb9K3w9szf5lAkb/SFXw+e+yPS9habkpOncL0oCsgag5wUGCEmZ7wpiY8QgARhuwsQUkxv1aUi/Nn7b7sAkKSkxtBI3LBXZ+vcUxZTH0ut4pe9rbrEed3ktAOF5FafjA1VtarPqqZ+g46xVO9llgpXcl3rVglFtXzTcUy09hGw== btobolaski@Brendans-MacBook-Pro.local"
+}`
+
+const testAccCheckLinodeLinodeConfig_Upsize_bigger = `
+resource "linode_linode" "foobar" {
+	name = "foobar_upsized"
+	group = "integration"
+	size = 2048
+	image = "Ubuntu 14.04 LTS"
+	region = "Dallas, TX, USA"
+	kernel = "Latest 64 bit"
+	root_password = "terraform-test"
+	ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCxtdizvJzTT38y2oXuoLUXbLUf9V0Jy9KsM0bgIvjUCSEbuLWCXKnWqgBmkv7iTKGZg3fx6JA10hiufdGHD7at5YaRUitGP2mvC2I68AYNZmLCGXh0hYMrrUB01OEXHaYhpSmXIBc9zUdTreL5CvYe3PAYzuBA0/lGFTnNsHosSd+suA4xfJWMr/Fr4/uxrpcy8N8BE16pm4kci5tcMh6rGUGtDEj6aE9k8OI4SRmSZJsNElsu/Z/K4zqCpkW/U06vOnRrE98j3NE07nxVOTqdAMZqopFiMP0MXWvd6XyS2/uKU+COLLc0+hVsgj+dVMTWfy8wZ58OJDsIKk/cI/7yF+GZz89Js+qYx7u9mNhpEgD4UrcRHpitlRgVhA8p6R4oBqb0m/rpKBd2BAFdcty3GIP9CWsARtsCbN6YDLJ1JN3xI34jSGC1ROktVHg27bEEiT5A75w3WJl96BlSo5zJsIZDTWlaqnr26YxNHba4ILdVLKigQtQpf8WFsnB9YzmDdb9K3w9szf5lAkb/SFXw+e+yPS9habkpOncL0oCsgag5wUGCEmZ7wpiY8QgARhuwsQUkxv1aUi/Nn7b7sAkKSkxtBI3LBXZ+vcUxZTH0ut4pe9rbrEed3ktAOF5FafjA1VtarPqqZ+g46xVO9llgpXcl3rVglFtXzTcUy09hGw== btobolaski@Brendans-MacBook-Pro.local"
+}`
+
+const testAccCheckLinodeLinodeConfig_Downsize = `
+resource "linode_linode" "foobar" {
+	name = "foobar_downsized"
+	group = "integration"
+	size = 1024
+	image = "Ubuntu 14.04 LTS"
+	region = "Dallas, TX, USA"
+	kernel = "Latest 64 bit"
+	root_password = "terraform-test"
+	ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCxtdizvJzTT38y2oXuoLUXbLUf9V0Jy9KsM0bgIvjUCSEbuLWCXKnWqgBmkv7iTKGZg3fx6JA10hiufdGHD7at5YaRUitGP2mvC2I68AYNZmLCGXh0hYMrrUB01OEXHaYhpSmXIBc9zUdTreL5CvYe3PAYzuBA0/lGFTnNsHosSd+suA4xfJWMr/Fr4/uxrpcy8N8BE16pm4kci5tcMh6rGUGtDEj6aE9k8OI4SRmSZJsNElsu/Z/K4zqCpkW/U06vOnRrE98j3NE07nxVOTqdAMZqopFiMP0MXWvd6XyS2/uKU+COLLc0+hVsgj+dVMTWfy8wZ58OJDsIKk/cI/7yF+GZz89Js+qYx7u9mNhpEgD4UrcRHpitlRgVhA8p6R4oBqb0m/rpKBd2BAFdcty3GIP9CWsARtsCbN6YDLJ1JN3xI34jSGC1ROktVHg27bEEiT5A75w3WJl96BlSo5zJsIZDTWlaqnr26YxNHba4ILdVLKigQtQpf8WFsnB9YzmDdb9K3w9szf5lAkb/SFXw+e+yPS9habkpOncL0oCsgag5wUGCEmZ7wpiY8QgARhuwsQUkxv1aUi/Nn7b7sAkKSkxtBI3LBXZ+vcUxZTH0ut4pe9rbrEed3ktAOF5FafjA1VtarPqqZ+g46xVO9llgpXcl3rVglFtXzTcUy09hGw== btobolaski@Brendans-MacBook-Pro.local"
+}`
+
+const testAccCheckLinodeLinodeConfig_Upsize_expand_disk = `
+resource "linode_linode" "foobar" {
+	name = "foobar_expanded"
 	group = "integration"
 	size = 2048
 	image = "Ubuntu 14.04 LTS"

--- a/resource_linode_test.go
+++ b/resource_linode_test.go
@@ -63,6 +63,30 @@ func TestAccLinodeLinode_Update(t *testing.T) {
 	})
 }
 
+func TestAccLinodeLinode_Resize(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLinodeLinodeDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckLinodeLinodeConfig_updates,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeLinodeExists("linode_linode.foobar"),
+					resource.TestCheckResourceAttr("linode_linode.foobar", "size", "1024"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckLinodeLinodeConfig_Resize,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeLinodeExists("linode_linode.foobar"),
+					resource.TestCheckResourceAttr("linode_linode.foobar", "size", "2048"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLinodeLinode_PrivateNetworking(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -178,6 +202,18 @@ resource "linode_linode" "foobar" {
 	name = "foobaz"
 	group = "integration"
 	size = 1024
+	image = "Ubuntu 14.04 LTS"
+	region = "Dallas, TX, USA"
+	kernel = "Latest 64 bit"
+	root_password = "terraform-test"
+	ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCxtdizvJzTT38y2oXuoLUXbLUf9V0Jy9KsM0bgIvjUCSEbuLWCXKnWqgBmkv7iTKGZg3fx6JA10hiufdGHD7at5YaRUitGP2mvC2I68AYNZmLCGXh0hYMrrUB01OEXHaYhpSmXIBc9zUdTreL5CvYe3PAYzuBA0/lGFTnNsHosSd+suA4xfJWMr/Fr4/uxrpcy8N8BE16pm4kci5tcMh6rGUGtDEj6aE9k8OI4SRmSZJsNElsu/Z/K4zqCpkW/U06vOnRrE98j3NE07nxVOTqdAMZqopFiMP0MXWvd6XyS2/uKU+COLLc0+hVsgj+dVMTWfy8wZ58OJDsIKk/cI/7yF+GZz89Js+qYx7u9mNhpEgD4UrcRHpitlRgVhA8p6R4oBqb0m/rpKBd2BAFdcty3GIP9CWsARtsCbN6YDLJ1JN3xI34jSGC1ROktVHg27bEEiT5A75w3WJl96BlSo5zJsIZDTWlaqnr26YxNHba4ILdVLKigQtQpf8WFsnB9YzmDdb9K3w9szf5lAkb/SFXw+e+yPS9habkpOncL0oCsgag5wUGCEmZ7wpiY8QgARhuwsQUkxv1aUi/Nn7b7sAkKSkxtBI3LBXZ+vcUxZTH0ut4pe9rbrEed3ktAOF5FafjA1VtarPqqZ+g46xVO9llgpXcl3rVglFtXzTcUy09hGw== btobolaski@Brendans-MacBook-Pro.local"
+}`
+
+const testAccCheckLinodeLinodeConfig_Resize = `
+resource "linode_linode" "foobar" {
+	name = "foobaz"
+	group = "integration"
+	size = 2048
 	image = "Ubuntu 14.04 LTS"
 	region = "Dallas, TX, USA"
 	kernel = "Latest 64 bit"

--- a/resource_linode_test.go
+++ b/resource_linode_test.go
@@ -97,6 +97,32 @@ func TestAccLinodeLinode_Resize(t *testing.T) {
 	})
 }
 
+func TestAccLinodeLinode_ExpandDisk(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLinodeLinodeDestroy,
+		Steps: []resource.TestStep{
+			// Start off with a Linode 1024
+			resource.TestStep{
+				Config: testAccCheckLinodeLinodeConfig_Upsize_small,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeLinodeExists("linode_linode.foobar"),
+					resource.TestCheckResourceAttr("linode_linode.foobar", "size", "1024"),
+				),
+			},
+			// Bump it to a 2048, and expand the disk
+			resource.TestStep{
+				Config: testAccCheckLinodeLinodeConfig_Upsize_expand_disk,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeLinodeExists("linode_linode.foobar"),
+					resource.TestCheckResourceAttr("linode_linode.foobar", "size", "2048"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLinodeLinode_PrivateNetworking(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -260,6 +286,7 @@ resource "linode_linode" "foobar" {
 	name = "foobar_expanded"
 	group = "integration"
 	size = 2048
+	disk_expansion = true
 	image = "Ubuntu 14.04 LTS"
 	region = "Dallas, TX, USA"
 	kernel = "Latest 64 bit"

--- a/resource_linode_test.go
+++ b/resource_linode_test.go
@@ -31,6 +31,7 @@ func TestAccLinodeLinode_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("linode_linode.foobar", "region", "Dallas, TX, USA"),
 					resource.TestCheckResourceAttr("linode_linode.foobar", "kernel", "Latest 64 bit"),
 					resource.TestCheckResourceAttr("linode_linode.foobar", "group", "testing"),
+					resource.TestCheckResourceAttr("linode_linode.foobar", "swap_size", "256"),
 				),
 			},
 		},
@@ -75,6 +76,7 @@ func TestAccLinodeLinode_Resize(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLinodeLinodeExists("linode_linode.foobar"),
 					resource.TestCheckResourceAttr("linode_linode.foobar", "size", "1024"),
+					resource.TestCheckResourceAttr("linode_linode.foobar", "plan_storage_utilized", "24576"),
 				),
 			},
 			// Bump it to a 2048, but don't expand the disk
@@ -83,6 +85,7 @@ func TestAccLinodeLinode_Resize(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLinodeLinodeExists("linode_linode.foobar"),
 					resource.TestCheckResourceAttr("linode_linode.foobar", "size", "2048"),
+					resource.TestCheckResourceAttr("linode_linode.foobar", "plan_storage_utilized", "24576"),
 				),
 			},
 			// Go back down to a 1024
@@ -109,6 +112,7 @@ func TestAccLinodeLinode_ExpandDisk(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLinodeLinodeExists("linode_linode.foobar"),
 					resource.TestCheckResourceAttr("linode_linode.foobar", "size", "1024"),
+					resource.TestCheckResourceAttr("linode_linode.foobar", "plan_storage_utilized", "24576"),
 				),
 			},
 			// Bump it to a 2048, and expand the disk
@@ -117,6 +121,7 @@ func TestAccLinodeLinode_ExpandDisk(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLinodeLinodeExists("linode_linode.foobar"),
 					resource.TestCheckResourceAttr("linode_linode.foobar", "size", "2048"),
+					resource.TestCheckResourceAttr("linode_linode.foobar", "plan_storage_utilized", "49152"),
 				),
 			},
 		},


### PR DESCRIPTION
- Support resizing Linodes
- Support expanding the root volume upon upsize of a Linode
- Added values to show a Linode's storage capacity based on its Linode plan size (`plan_storage`) and the total size of all a Linodes volumes (`plan_storage_utilized`)
- Support using an `imageID` instead of only the `imageName` for deployment
- Adjusted disk naming behavior to account for Linode 50 character `diskName` limitation
- Allow configuration of Linode swap size
- Added/updated tests and documentation
